### PR TITLE
Add a callback to be invoked before retrying a request

### DIFF
--- a/auth.go
+++ b/auth.go
@@ -3,6 +3,7 @@ package reggie
 import (
 	"encoding/json"
 	"errors"
+	"fmt"
 	"regexp"
 	"strings"
 
@@ -37,7 +38,10 @@ func (client *Client) retryRequestWithAuth(originalRequest *Request, originalRes
 	}
 
 	if originalRequest.retryCallback != nil {
-		originalRequest.retryCallback(originalRequest)
+		err := originalRequest.retryCallback(originalRequest)
+		if err != nil {
+			return nil, fmt.Errorf("retry callback returned error: %s", err)
+		}
 	}
 
 	authenticationType := authHeaderMatcher.ReplaceAllString(authHeaderRaw, "$1")

--- a/auth.go
+++ b/auth.go
@@ -36,6 +36,10 @@ func (client *Client) retryRequestWithAuth(originalRequest *Request, originalRes
 		originalRequest.QueryParam.Del(k)
 	}
 
+	if originalRequest.retryCallback != nil {
+		originalRequest.retryCallback(originalRequest)
+	}
+
 	authenticationType := authHeaderMatcher.ReplaceAllString(authHeaderRaw, "$1")
 	if strings.EqualFold(authenticationType, "bearer") {
 		h := parseAuthHeader(authHeaderRaw)

--- a/client.go
+++ b/client.go
@@ -133,7 +133,10 @@ func (client *Client) NewRequest(method string, path string, opts ...requestOpti
 	restyRequest.URL = url
 	restyRequest.SetHeader("User-Agent", client.Config.UserAgent)
 
-	return &Request{restyRequest}
+	return &Request{
+		Request:       restyRequest,
+		retryCallback: r.RetryCallback,
+	}
 }
 
 // Do executes a Request and returns a Response.

--- a/client_test.go
+++ b/client_test.go
@@ -260,6 +260,21 @@ func TestClient(t *testing.T) {
 		t.Fatalf("Expected body to be \"abc\" but instead got %s", lastCapturedRequestBodyStr)
 	}
 
+	// Test that the retry callback is invoked, if configured.
+	newBody := "not the original body"
+	req = client.NewRequest(PUT, "/a/b/c", WithRetryCallback(func(r *Request) {
+		r.SetBody(newBody)
+	})).SetBody([]byte("original body"))
+	_, err = client.Do(req)
+	if err != nil {
+		t.Fatalf("Errors executing request: %s", err)
+	}
+
+	// Ensure the request ended up with the new body.
+	if lastCapturedRequestBodyStr != newBody {
+		t.Fatalf("Expected body to be %q, but instead got %q", newBody, lastCapturedRequestBodyStr)
+	}
+
 	// test for access_token vs. token
 	authUseAccessToken = true
 	req = client.NewRequest(GET, "/v2/<name>/tags/list")

--- a/request.go
+++ b/request.go
@@ -8,10 +8,14 @@ import (
 )
 
 type (
+	// RetryCallbackFunc is a function that can mutate a request prior to it
+	// being retried.
+	RetryCallbackFunc func(*Request) error
+
 	// Request is an HTTP request to be sent to an OCI registry.
 	Request struct {
 		*resty.Request
-		retryCallback func(*Request)
+		retryCallback RetryCallbackFunc
 	}
 
 	requestConfig struct {
@@ -19,7 +23,7 @@ type (
 		Reference     string
 		Digest        string
 		SessionID     string
-		RetryCallback func(*Request)
+		RetryCallback RetryCallbackFunc
 	}
 
 	requestOption func(c *requestConfig)
@@ -56,7 +60,7 @@ func WithSessionID(id string) requestOption {
 // WithRetryCallback specifies a callback that will be invoked before a request
 // is retried. This is useful for, e.g., ensuring an io.Reader used for the body
 // will produce the right content on retry.
-func WithRetryCallback(cb func(*Request)) requestOption {
+func WithRetryCallback(cb RetryCallbackFunc) requestOption {
 	return func(c *requestConfig) {
 		c.RetryCallback = cb
 	}

--- a/request.go
+++ b/request.go
@@ -11,13 +11,15 @@ type (
 	// Request is an HTTP request to be sent to an OCI registry.
 	Request struct {
 		*resty.Request
+		retryCallback func(*Request)
 	}
 
 	requestConfig struct {
-		Name      string
-		Reference string
-		Digest    string
-		SessionID string
+		Name          string
+		Reference     string
+		Digest        string
+		SessionID     string
+		RetryCallback func(*Request)
 	}
 
 	requestOption func(c *requestConfig)
@@ -48,6 +50,15 @@ func WithDigest(digest string) requestOption {
 func WithSessionID(id string) requestOption {
 	return func(c *requestConfig) {
 		c.SessionID = id
+	}
+}
+
+// WithRetryCallback specifies a callback that will be invoked before a request
+// is retried. This is useful for, e.g., ensuring an io.Reader used for the body
+// will produce the right content on retry.
+func WithRetryCallback(cb func(*Request)) requestOption {
+	return func(c *requestConfig) {
+		c.RetryCallback = cb
 	}
 }
 


### PR DESCRIPTION
When using an `io.Reader` as the request body, it's possible for some of the body to be read by the initial, unauthenticated attempt. When this happens, the authenticated retry attempt will not transmit the full body.

To accommodate this, add a callback to the request and invoke it before performing a retry. This gives callers the opportunity to make any necessary adjustments to the body (or other parts of the request) before the request is retried.

Signed-off-by: Adam Wolfe Gordon <awg@digitalocean.com>