### PR TITLE
adding simple validation checks to reggie client

### DIFF
--- a/README.md
+++ b/README.md
@@ -258,3 +258,36 @@ func main() {
 	fmt.Printf("Manifest content:\n%s\n", resp.String())
 }
 ```
+
+## Development
+
+To develop bloodorangeio/reggie, you will need to have [Go installed](https://golang.org/doc/install).
+You should then fork the repository, clone the fork, and checkout a new branch.
+
+```bash
+git clone https://github.com/<username>/reggie
+cd reggie 
+git checkout -b add/my-new-feature
+```
+
+You can then make changes to the code, and build as needed. But if you are just
+making local changes that you want to test alongside the library, you should edit
+[client_test.go](client_test.go) and then run tests.
+
+```bash
+$ go test
+2020/10/19 15:11:34.226399 WARN RESTY Using Basic Auth in HTTP mode is not secure, use HTTPS
+2020/10/19 15:11:34.227171 WARN RESTY Using Basic Auth in HTTP mode is not secure, use HTTPS
+2020/10/19 15:11:34.227620 WARN RESTY Using Basic Auth in HTTP mode is not secure, use HTTPS
+2020/10/19 15:11:34.228231 WARN RESTY Using Basic Auth in HTTP mode is not secure, use HTTPS
+2020/10/19 15:11:34.228650 WARN RESTY Using Basic Auth in HTTP mode is not secure, use HTTPS
+2020/10/19 15:11:34.229178 WARN RESTY Using Basic Auth in HTTP mode is not secure, use HTTPS
+PASS
+ok  	github.com/bloodorangeio/reggie	0.006s
+```
+
+Before submitting a pull request, make sure to format the code.
+
+```bash
+go fmt
+```

--- a/client.go
+++ b/client.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/asaskevich/govalidator"
 	"github.com/go-resty/resty/v2"
 )
 
@@ -42,6 +43,13 @@ func (c *clientConfig) validate() error {
 	if c.Address == "" {
 		return fmt.Errorf("Address is required")
 	}
+
+	// Validate the url
+	isValid := govalidator.IsURL(c.Address)
+	if !isValid {
+		return fmt.Errorf("%s is not a valid URL", c.Address)
+	}
+
 	if c.UserAgent == "" {
 		return fmt.Errorf("UserAgent is required")
 	}

--- a/client.go
+++ b/client.go
@@ -35,6 +35,19 @@ type (
 	clientOption func(c *clientConfig)
 )
 
+// validate the client config.
+func (c *clientConfig) validate() error {
+
+	// Check that both Address and UserAgent are defined
+	if c.Address == "" {
+		return fmt.Errorf("Address is required")
+	}
+	if c.UserAgent == "" {
+		return fmt.Errorf("UserAgent is required")
+	}
+	return nil
+}
+
 // NewClient builds a new Client from provided options.
 func NewClient(address string, opts ...clientOption) (*Client, error) {
 	conf := &clientConfig{}
@@ -46,7 +59,11 @@ func NewClient(address string, opts ...clientOption) (*Client, error) {
 		conf.UserAgent = DefaultUserAgent
 	}
 
-	// TODO: validate config here, return error if it aint no good
+	// Validate the config
+	err := conf.validate()
+	if err != nil {
+		return nil, err
+	}
 
 	client := Client{}
 	client.Client = resty.New()

--- a/client_test.go
+++ b/client_test.go
@@ -220,15 +220,10 @@ func TestClient(t *testing.T) {
 		t.Fatalf("Expected error with missing session id")
 	}
 
-	// bad address on client
-	badClient, err := NewClient("xwejknxw://jshnws")
-	if err != nil {
-		t.Fatalf("Errors creating client with bad address: %s", err)
-	}
-	req = badClient.NewRequest(GET, "/v2/<name>/tags/list", WithName("customname"))
-	resp, err = badClient.Do(req)
+	// bad address on client should not create
+	_, err = NewClient("xwejknxw://jshnws")
 	if err == nil {
-		t.Fatalf("Expected error with bad address")
+		t.Fatalf("Should be errors creating client with bad address: %s", err)
 	}
 
 	// Make sure headers and body match after going through auth

--- a/client_test.go
+++ b/client_test.go
@@ -62,7 +62,14 @@ func TestClient(t *testing.T) {
 	}))
 	defer registryTestServer.Close()
 
-	client, err := NewClient(registryTestServer.URL,
+	// test client without Address is invalid
+	client, err := NewClient("")
+	if err == nil {
+		t.Fatalf("Providing empty Address should throw error: %s", err)
+	}
+
+	// test creating generic client
+	client, err = NewClient(registryTestServer.URL,
 		WithUsernamePassword("testuser", "testpass"),
 		WithDefaultName("testname"),
 		WithUserAgent("reggie-tests"))

--- a/error.go
+++ b/error.go
@@ -7,8 +7,8 @@ type (
 
 	// ErrorInfo describes a server error returned from a registry.
 	ErrorInfo struct {
-		Code    string `json:"code"`
-		Message string `json:"message"`
+		Code    string      `json:"code"`
+		Message string      `json:"message"`
 		Detail  interface{} `json:"detail"`
 	}
 )

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/bloodorangeio/reggie
 go 1.13
 
 require (
+	github.com/asaskevich/govalidator v0.0.0-20200907205600-7a23bdc65eef
 	github.com/go-resty/resty/v2 v2.1.0
 	github.com/mitchellh/mapstructure v1.1.2
 	github.com/opencontainers/distribution-spec v1.0.0-rc0.0.20200108182153-219f20cbcfa1

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,5 @@
+github.com/asaskevich/govalidator v0.0.0-20200907205600-7a23bdc65eef h1:46PFijGLmAjMPwCCCo7Jf0W6f9slllCkkv7vyc1yOSg=
+github.com/asaskevich/govalidator v0.0.0-20200907205600-7a23bdc65eef/go.mod h1:WaHUgvxTVq04UNunO+XhnAqY/wQc+bxr74GqbsZ/Jqw=
 github.com/go-resty/resty/v2 v2.1.0 h1:Z6IefCpUMfnvItVJaJXWv/pMiiD11So35QgwEELsldE=
 github.com/go-resty/resty/v2 v2.1.0/go.mod h1:dZGr0i9PLlaaTD4H/hoZIDjQ+r6xq8mgbRzHZf7f2J8=
 github.com/mitchellh/mapstructure v1.1.2 h1:fmNYVwqnSfB9mZU6OS2O6GsXM+wcskZDuKQzvN1EDeE=


### PR DESCRIPTION
This will add basic checks to validate the client config, along with brief notes for development in the README to close #24. We discussed checking for an empty UserAgent, but it looks like this isn't possible (at least when called in the NewClient function). I tried various tricks to instantiate the client for the test and then change the UserAgent to an empty string, but always got memory / reference errors. So if it's not possible, we might just remove it. If it's possible, I'd want to know how and then adjust the test.

Signed-off-by: vsoch <vsochat@stanford.edu>