### PR TITLE
use consistent means to return an empty string for both GetRelative/Absolute Location

### DIFF
--- a/response.go
+++ b/response.go
@@ -36,7 +36,12 @@ func (resp *Response) GetRelativeLocation() string {
 // GetAbsoluteLocation returns the full URL, including protocol and host,
 // of the location contained in the `Location` header of the response.
 func (resp *Response) GetAbsoluteLocation() string {
-	return resp.Header().Get("Location")
+	loc := resp.Header().Get("Location")
+	_, err := url.Parse(loc)
+	if err != nil {
+		return ""
+	}
+	return loc
 }
 
 // IsUnauthorized returns whether or not the response is a 401


### PR DESCRIPTION
I'm not sure that this is the best way to go about it, but in GetAbsoluteLocation we can validate the result of the Header.Get() with the same url.parse, and return an empty string (akin to GetRelativeLocation) if it doesn't parse. And then return the location otherwise. This will address an issue discussed in #28. Let me know if you'd like me to try something else!

Signed-off-by: vsoch <vsoch@users.noreply.github.com>