### PR TITLE
Only set Authorization header when Config.Username is defined

### DIFF
--- a/auth.go
+++ b/auth.go
@@ -50,8 +50,10 @@ func (client *Client) retryRequestWithAuth(originalRequest *Request, originalRes
 		req := client.Client.NewRequest().
 			SetQueryParam("service", h.Service).
 			SetHeader("Accept", "application/json").
-			SetHeader("User-Agent", client.Config.UserAgent).
-			SetBasicAuth(client.Config.Username, client.Config.Password)
+			SetHeader("User-Agent", client.Config.UserAgent)
+		if client.Config.Username != "" {
+			req.SetBasicAuth(client.Config.Username, client.Config.Password)
+		}
 		if s := client.Config.AuthScope; s != "" {
 			req.SetQueryParam("scope", s)
 		} else if h.Scope != "" {


### PR DESCRIPTION
This allows reggie to pull anonymously (no username/password set in the reggie config) when pulling from docker hub (`https://registry.docker.com`).

The docker auth login request will still be performed to fetch a token, but it is allowed to proceed when their is no Authorization header. Without this change, reggie will always return a 401 http error (Not Authorized) when requesting the auth token.